### PR TITLE
fix: use Salesforce/wikitext namespace in load_dataset

### DIFF
--- a/main.py
+++ b/main.py
@@ -265,7 +265,7 @@ class TextDataset(Dataset):
 
 def load_training_data(max_samples=None):
     print("Loading dataset: wikitext-103-raw-v1...")
-    dataset = load_dataset("wikitext", "wikitext-103-raw-v1", split="train")
+    dataset = load_dataset("Salesforce/wikitext", "wikitext-103-raw-v1", split="train")
     texts = [item["text"] for item in dataset if item["text"].strip()]
     if max_samples:
         texts = texts[:max_samples]


### PR DESCRIPTION
Fixes #4

`load_dataset("wikitext", ...)` fails on newer versions of `huggingface_hub` (≥ 0.24) which require dataset IDs to follow the `namespace/name` format.

The `wikitext` dataset is now hosted under the `Salesforce` organization on Hugging Face, so the unqualified short name no longer resolves.